### PR TITLE
Upgrade to polysemy 1.7

### DIFF
--- a/polysemy-mocks.cabal
+++ b/polysemy-mocks.cabal
@@ -28,7 +28,7 @@ library
   ghc-options: -Wall
   build-depends:
       base >=4.7 && <5
-    , polysemy
+    , polysemy >= 1.7
     , template-haskell
   exposed-modules:
       Test.Polysemy.Mock
@@ -43,7 +43,7 @@ test-suite tests
   build-depends:
       base >=4.7 && <5
     , hspec
-    , polysemy
+    , polysemy >= 1.7
     , polysemy-mocks
   default-language: Haskell2010
   other-modules:

--- a/src/Test/Polysemy/Mock/TH.hs
+++ b/src/Test/Polysemy/Mock/TH.hs
@@ -20,7 +20,7 @@ import Test.Polysemy.Mock
 -- @
 genMock :: Name -> Q [Dec]
 genMock effName = do
-  (_, constructors) <- getEffectMetadata effName
+  constructors <- getEffectMetadata effName
   -- MockImpl
   let mockImplEffectType = ConT ''MockImpl `AppT` ConT effName `AppT` returnsEffect
   let mockImplReturnType = mockImplEffectType `AppT` VarT (mkName "m")

--- a/stack-8.8.yaml
+++ b/stack-8.8.yaml
@@ -3,5 +3,8 @@ resolver: lts-16.31
 packages:
 - .
 
+extra-deps:
+- polysemy-1.7.0.0@sha256:c972f33191113e2fe6809ea1cda24a6cabfeed2f115b3be0137dee7c65d08293,5977
+
 nix:
   shell-file: stack-deps-8.8.nix

--- a/stack-8.8.yaml.lock
+++ b/stack-8.8.yaml.lock
@@ -3,7 +3,14 @@
 # For more information, please see the documentation at:
 #   https://docs.haskellstack.org/en/stable/lock_files
 
-packages: []
+packages:
+- completed:
+    hackage: polysemy-1.7.0.0@sha256:c972f33191113e2fe6809ea1cda24a6cabfeed2f115b3be0137dee7c65d08293,5977
+    pantry-tree:
+      size: 4577
+      sha256: 78c733f5dde13340e880bbb883dc64af948f6449da3a4025811cdc79c204dfde
+  original:
+    hackage: polysemy-1.7.0.0@sha256:c972f33191113e2fe6809ea1cda24a6cabfeed2f115b3be0137dee7c65d08293,5977
 snapshots:
 - completed:
     size: 534126

--- a/stack.yaml
+++ b/stack.yaml
@@ -5,7 +5,7 @@ packages:
 
 extra-deps:
 - ghc-tcplugins-extra-0.3.2@sha256:1bbfd4449c3669a31618ea0ebc5d00d980a53988daad3b6218bab5c8cdff268d,1687
-- polysemy-1.3.0.0@sha256:bf1d559c7e26e8a0ed31fc45d84635e329a4a31bfd39e713a39adf639bcbd309,6141
+- polysemy-1.7.0.0@sha256:c972f33191113e2fe6809ea1cda24a6cabfeed2f115b3be0137dee7c65d08293,5977
 - th-abstraction-0.3.2.0@sha256:9b5b4e6e2bbff9b075ad7751ee98e2107090bd17b51d5442695b8990e4db6521,1851
 
 nix:

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -12,12 +12,12 @@ packages:
   original:
     hackage: ghc-tcplugins-extra-0.3.2@sha256:1bbfd4449c3669a31618ea0ebc5d00d980a53988daad3b6218bab5c8cdff268d,1687
 - completed:
-    hackage: polysemy-1.3.0.0@sha256:bf1d559c7e26e8a0ed31fc45d84635e329a4a31bfd39e713a39adf639bcbd309,6141
+    hackage: polysemy-1.7.0.0@sha256:c972f33191113e2fe6809ea1cda24a6cabfeed2f115b3be0137dee7c65d08293,5977
     pantry-tree:
-      size: 4309
-      sha256: 770af8c91981ccb8fe388ba62897fdf4eb394df433ab10def66d6e111b6f09f7
+      size: 4577
+      sha256: 78c733f5dde13340e880bbb883dc64af948f6449da3a4025811cdc79c204dfde
   original:
-    hackage: polysemy-1.3.0.0@sha256:bf1d559c7e26e8a0ed31fc45d84635e329a4a31bfd39e713a39adf639bcbd309,6141
+    hackage: polysemy-1.7.0.0@sha256:c972f33191113e2fe6809ea1cda24a6cabfeed2f115b3be0137dee7c65d08293,5977
 - completed:
     hackage: th-abstraction-0.3.2.0@sha256:9b5b4e6e2bbff9b075ad7751ee98e2107090bd17b51d5442695b8990e4db6521,1851
     pantry-tree:


### PR DESCRIPTION
Fix for https://github.com/akshaymankar/polysemy-mocks/issues/2.

This makes polysemy-mocks compile with polysemy 1.7 (and updates the cabal file bounds). I haven't touched any of the stack and nix stuff, though, so probably this breaks when built with those. I'm not sure how you want to deal with that, since this version is not in a snapshot yet. CPP maybe?